### PR TITLE
feat(admin): Add user management APIs for admin (create, update statu…

### DIFF
--- a/auth-service/src/main/java/com/BE/controller/AuthenticationController.java
+++ b/auth-service/src/main/java/com/BE/controller/AuthenticationController.java
@@ -126,10 +126,7 @@ public class AuthenticationController {
         return ResponseEntity.ok(iAuthenticationService.admin());
     }
 
-    @PatchMapping("/status")
-    public ResponseEntity status(@Valid @RequestBody StatusRequest statusRequest) {
-        return ResponseEntity.ok(statusRequest.getStatus());
-    }
+
 
 
 }

--- a/auth-service/src/main/java/com/BE/controller/UserController.java
+++ b/auth-service/src/main/java/com/BE/controller/UserController.java
@@ -1,10 +1,16 @@
 package com.BE.controller;
 
+import com.BE.enums.GenderEnum;
+import com.BE.enums.RoleEnum;
+import com.BE.enums.StatusEnum;
+import com.BE.model.request.CreateUserRequest;
+import com.BE.model.request.StatusRequest;
 import com.BE.model.request.UserProfileRequest;
 import com.BE.model.response.UserResponse;
 import com.BE.service.interfaceServices.IUserService;
 import com.BE.utils.ResponseHandler;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -69,6 +75,83 @@ public class UserController {
     public ResponseEntity update(@PathVariable UUID id,
                                  @RequestBody @Valid UserProfileRequest request) {
         return responseHandler.response(200, "Cập nhật hồ sơ thành công", userService.update(id, request));
+    }
+
+    @PostMapping
+    @Operation(
+            summary = "Tạo mới người dùng",
+            description = "Chỉ dành cho Admin. Tạo tài khoản mới với thông tin cơ bản và phân quyền vai trò."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Tạo mới người dùng thành công"),
+            @ApiResponse(responseCode = "400", description = "Dữ liệu không hợp lệ hoặc tài khoản đã tồn tại")
+    })
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "Thông tin người dùng cần tạo",
+            required = true,
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = CreateUserRequest.class),
+                    examples = @ExampleObject(
+                            name = "Ví dụ tạo người dùng",
+                            value = """
+                                    {
+                                      "fullName": "partner",
+                                      "username": "partner",
+                                      "password": "partner",
+                                      "email": "partner@gmail.com",                     
+                                      "role": "PARTNER"
+                                    }
+                                    """
+                    )
+            )
+    )
+    public ResponseEntity<?> create(@Valid @RequestBody CreateUserRequest request) {
+        return responseHandler.response(201, "Tạo mới người dùng thành công", userService.create(request));
+    }
+
+    @PatchMapping("/{id}/status")
+    @Operation(
+            summary = "Cập nhật trạng thái người dùng",
+            description = "Chỉ dành cho Admin. Cho phép thay đổi trạng thái tài khoản của người dùng (ACTIVE, INACTIVE, BANNED)."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Cập nhật trạng thái thành công"),
+            @ApiResponse(responseCode = "404", description = "Không tìm thấy người dùng")
+    })
+    public ResponseEntity<?> updateStatus(@PathVariable UUID id, @Valid @RequestBody StatusRequest request) {
+        return responseHandler.response(200,"Cập nhật trạng thái người dùng thành công", userService.updateStatus(id, request.getStatus()));
+    }
+
+
+    @Operation(
+            summary = "Lấy danh sách người dùng với tìm kiếm và lọc",
+            description = "Tìm kiếm theo tên (`search`), lọc theo vai trò (`role`), trạng thái (`status`), giới tính (`gender`) và sắp xếp theo `createdAt` hoặc `updatedAt` theo chiều `asc|desc`.",
+            parameters = {
+                    @Parameter(name = "search", description = "Từ khóa tìm kiếm theo họ tên"),
+                    @Parameter(name = "role", description = "Vai trò người dùng", schema = @Schema(implementation = RoleEnum.class)),
+                    @Parameter(name = "status", description = "Trạng thái người dùng", schema = @Schema(implementation = StatusEnum.class)),
+                    @Parameter(name = "gender", description = "Giới tính", schema = @Schema(implementation = GenderEnum.class)),
+                    @Parameter(name = "sortBy", description = "Trường sắp xếp", schema = @Schema(allowableValues = {"createdAt", "updatedAt"}), example = "createdAt"),
+                    @Parameter(name = "sortDirection", description = "Chiều sắp xếp", schema = @Schema(allowableValues = {"asc", "desc"}), example = "desc"),
+                    @Parameter(name = "offset", description = "Số trang (bắt đầu từ 1)", schema = @Schema(example = "1")),
+                    @Parameter(name = "pageSize", description = "Số phần tử mỗi trang", schema = @Schema(example = "10"))
+            }
+    )
+    @GetMapping
+    public ResponseEntity<?> getUsers(
+            @RequestParam(required = false) String search,
+            @RequestParam(required = false) RoleEnum role,
+            @RequestParam(required = false) StatusEnum status,
+            @RequestParam(required = false) GenderEnum gender,
+            @RequestParam(defaultValue = "createdAt") String sortBy,
+            @RequestParam(defaultValue = "desc") String sortDirection,
+            @RequestParam(defaultValue = "1") int offset,
+            @RequestParam(defaultValue = "10") int pageSize
+    ) {
+        return responseHandler.response(200, "Danh sách người dùng", userService.getUsersWithFilter(
+                        search, role, status, gender, offset, pageSize, sortBy, sortDirection
+                ));
     }
 
 }

--- a/auth-service/src/main/java/com/BE/mapper/UserMapper.java
+++ b/auth-service/src/main/java/com/BE/mapper/UserMapper.java
@@ -1,6 +1,7 @@
 package com.BE.mapper;
 
 import com.BE.model.entity.User;
+import com.BE.model.request.CreateUserRequest;
 import com.BE.model.request.UserProfileRequest;
 import com.BE.model.response.UserResponse;
 import org.mapstruct.BeanMapping;
@@ -15,5 +16,7 @@ public interface UserMapper {
     void update(@MappingTarget User user, UserProfileRequest request);
 
     UserResponse toResponse(User user);
+
+    User toEntity(CreateUserRequest createUserRequest);
 
 }

--- a/auth-service/src/main/java/com/BE/model/entity/User.java
+++ b/auth-service/src/main/java/com/BE/model/entity/User.java
@@ -2,6 +2,7 @@ package com.BE.model.entity;
 
 import com.BE.enums.GenderEnum;
 import com.BE.enums.RoleEnum;
+import com.BE.enums.StatusEnum;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
@@ -42,6 +43,9 @@ public class User implements UserDetails {
 
     @Enumerated(value = EnumType.STRING)
     RoleEnum role;
+
+    @Enumerated(value = EnumType.STRING)
+    StatusEnum status;
 
     String fullName;
 

--- a/auth-service/src/main/java/com/BE/model/request/CreateUserRequest.java
+++ b/auth-service/src/main/java/com/BE/model/request/CreateUserRequest.java
@@ -1,0 +1,44 @@
+package com.BE.model.request;
+
+import com.BE.enums.RoleEnum;
+import com.BE.enums.StatusEnum;
+import com.BE.exception.EnumValidator;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CreateUserRequest {
+
+    @NotBlank(message = "Họ tên không được để trống")
+    @Size(max = 100, message = "Họ tên không được vượt quá 100 ký tự")
+    @Schema(example = "Nguyễn Văn A")
+    String fullName;
+
+    @Email(message = "Email không hợp lệ", regexp = "^[a-zA-Z0-9_!#$%&'*+/=?`{|}~^.-]+@[a-zA-Z0-9.-]+$")
+    @NotBlank(message = "Email không được để trống")
+    String email;
+
+    @Size(min = 5, message = "Tên người dùng phải có ít nhất 5 ký tự")
+    @NotBlank(message = "Tên người dùng không được để trống")
+    String username;
+
+    @NotBlank(message = "Mật khẩu không được để trống")
+    @Size(min = 5, message = "Mật khẩu phải có ít nhất 5 ký tự")
+    String password;
+
+    @Schema(example = "TEACHER, STAFF, PARTNER", description = "Role Enum")
+    @EnumValidator(enumClass = RoleEnum.class, message = "Giá trị vai trò không hợp lệ")
+    @Enumerated(EnumType.STRING)
+    RoleEnum role;
+}

--- a/auth-service/src/main/java/com/BE/model/request/StatusRequest.java
+++ b/auth-service/src/main/java/com/BE/model/request/StatusRequest.java
@@ -20,7 +20,7 @@ import lombok.experimental.FieldDefaults;
 public class StatusRequest {
 
     @Schema(example = "ACTIVE, INACTIVE", description = "Status Enum")
-    @EnumValidator(enumClass = StatusEnum.class, message = "Invalid status value")
+    @EnumValidator(enumClass = StatusEnum.class, message = "Giá trị trạng thái không hợp lệ")
     @Enumerated(EnumType.STRING)
     StatusEnum status;
 

--- a/auth-service/src/main/java/com/BE/model/response/AuthenticationResponse.java
+++ b/auth-service/src/main/java/com/BE/model/response/AuthenticationResponse.java
@@ -3,6 +3,7 @@ package com.BE.model.response;
 
 import com.BE.enums.GenderEnum;
 import com.BE.enums.RoleEnum;
+import com.BE.enums.StatusEnum;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -30,6 +31,7 @@ public class AuthenticationResponse {
      String avatar;
      GenderEnum gender;
      LocalDate birthday;
+     StatusEnum status;
      LocalDateTime createdAt;
      LocalDateTime updatedAt;
      String token;

--- a/auth-service/src/main/java/com/BE/model/response/UserResponse.java
+++ b/auth-service/src/main/java/com/BE/model/response/UserResponse.java
@@ -3,6 +3,7 @@ package com.BE.model.response;
 
 import com.BE.enums.GenderEnum;
 import com.BE.enums.RoleEnum;
+import com.BE.enums.StatusEnum;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 
@@ -26,6 +27,7 @@ public class UserResponse {
     String avatar;
     GenderEnum gender;
     LocalDate birthday;
+    StatusEnum status;
     LocalDateTime createdAt;
     LocalDateTime updatedAt;
 }

--- a/auth-service/src/main/java/com/BE/repository/AuthenRepository.java
+++ b/auth-service/src/main/java/com/BE/repository/AuthenRepository.java
@@ -2,13 +2,14 @@ package com.BE.repository;
 
 import com.BE.model.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 import java.util.UUID;
 
 @Repository
-public interface AuthenRepository extends JpaRepository<User, UUID> {
+public interface AuthenRepository extends JpaRepository<User, UUID>, JpaSpecificationExecutor<User> {
     Optional<User> findByUsername(String username);
 
     Optional<User> findByEmail(String email);

--- a/auth-service/src/main/java/com/BE/service/implementServices/UserServiceImpl.java
+++ b/auth-service/src/main/java/com/BE/service/implementServices/UserServiceImpl.java
@@ -1,17 +1,29 @@
 package com.BE.service.implementServices;
 
+import com.BE.enums.GenderEnum;
+import com.BE.enums.RoleEnum;
+import com.BE.enums.StatusEnum;
 import com.BE.exception.exceptions.NotFoundException;
 import com.BE.mapper.UserMapper;
 import com.BE.model.entity.User;
+import com.BE.model.request.CreateUserRequest;
 import com.BE.model.request.UserProfileRequest;
 import com.BE.model.response.UserResponse;
 import com.BE.repository.AuthenRepository;
 import com.BE.service.interfaceServices.IUserService;
+import com.BE.utils.PageUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 import static lombok.AccessLevel.PRIVATE;
@@ -23,6 +35,8 @@ public class UserServiceImpl implements IUserService {
 
     AuthenRepository repository;
     UserMapper mapper;
+    PasswordEncoder passwordEncoder;
+    PageUtil pageUtil;
 
 
     @Override
@@ -32,4 +46,53 @@ public class UserServiceImpl implements IUserService {
         mapper.update(existing, request);
         return mapper.toResponse(repository.save(existing));
     }
+
+    @Override
+    public UserResponse create(CreateUserRequest request) {
+        User user = mapper.toEntity(request);
+        user.setPassword(passwordEncoder.encode(request.getPassword()));
+        try{
+            return mapper.toResponse(repository.save(user));
+        } catch (DataIntegrityViolationException e) {
+            System.out.println(e.getMessage());
+            throw new DataIntegrityViolationException("Đã có username này!");
+        }
+    }
+
+    @Override
+    public UserResponse updateStatus(UUID id, StatusEnum status) {
+        User user = repository.findById(id).orElseThrow(() -> new NotFoundException("Không tìm thấy người dùng"));
+        user.setStatus(status);
+        return mapper.toResponse(repository.save(user));
+    }
+
+
+    @Override
+    public Page<UserResponse> getUsersWithFilter(String search, RoleEnum role, StatusEnum status, GenderEnum gender,
+                                                 int offset, int pageSize,
+                                                 String sortBy, String sortDirection) {
+        pageUtil.checkOffset(offset);
+        Sort sort = Sort.by(Sort.Direction.fromString(sortDirection), sortBy);
+        Pageable pageable = PageRequest.of(offset - 1, pageSize, sort);
+
+        Specification<User> spec = Specification.where(null);
+
+        if (StringUtils.hasText(search)) {
+            spec = spec.and((root, query, cb) -> cb.like(cb.lower(root.get("fullName")), "%" + search.toLowerCase() + "%"));
+        }
+
+        if (role != null) {
+            spec = spec.and((root, query, cb) -> cb.equal(root.get("role"), role));
+        }
+
+        if (status != null) {
+            spec = spec.and((root, query, cb) -> cb.equal(root.get("status"), status));
+        }
+
+        if (gender != null) {
+            spec = spec.and((root, query, cb) -> cb.equal(root.get("gender"), gender));
+        }
+        return repository.findAll(spec, pageable).map(mapper::toResponse);
+    }
+
 }

--- a/auth-service/src/main/java/com/BE/service/interfaceServices/IUserService.java
+++ b/auth-service/src/main/java/com/BE/service/interfaceServices/IUserService.java
@@ -1,12 +1,27 @@
 package com.BE.service.interfaceServices;
 
+import com.BE.enums.GenderEnum;
+import com.BE.enums.RoleEnum;
+import com.BE.enums.StatusEnum;
+import com.BE.model.request.CreateUserRequest;
 import com.BE.model.request.UserProfileRequest;
 import com.BE.model.response.AuthenticationResponse;
 import com.BE.model.response.UserResponse;
+import org.springframework.data.domain.Page;
 
 import java.util.UUID;
 
 public interface IUserService {
 
     UserResponse update(UUID id, UserProfileRequest request);
+
+    UserResponse create(CreateUserRequest request);
+
+    UserResponse updateStatus(UUID id, StatusEnum status);
+
+    Page<UserResponse> getUsersWithFilter(String search, RoleEnum role, StatusEnum status, GenderEnum gender,
+                                          int offset, int pageSize,
+                                          String sortBy, String sortDirection);
+
+
 }


### PR DESCRIPTION
- Added full CRUD setup for user entity (limited to CREATE and STATUS UPDATE for admin)
- Admin can:
  - Create new user accounts with any role
  - Change user status (ACTIVE/INACTIVE)
  - Search users by full name
  - Filter by status, role, gender
  - Sort by createdAt or updatedAt
  - Paginate results
- Integrated JpaSpecificationExecutor for dynamic querying
- Added detailed validation (in Vietnamese) and request field examples using Swagger annotations
- Prevented admin from modifying user profile info directly