### PR TITLE
refactor: replace workspaceId with academicYearId in tool result flow

### DIFF
--- a/PlanBook-Aggregator/src/main/java/com/BE/model/request/ToolExecuteRequest.java
+++ b/PlanBook-Aggregator/src/main/java/com/BE/model/request/ToolExecuteRequest.java
@@ -49,8 +49,8 @@ public class ToolExecuteRequest {
             example = "1",
             required = true
     )
-    @NotNull(message = "WorkspaceId không được để trống")
-    Long workspaceId;
+    @NotNull(message = "AcademicYearId không được để trống")
+    Long academicYearId;
 
     @Schema(
             description = "ID của toolResult",

--- a/PlanBook-Aggregator/src/main/java/com/BE/model/request/ToolExecutionLogRequest.java
+++ b/PlanBook-Aggregator/src/main/java/com/BE/model/request/ToolExecutionLogRequest.java
@@ -44,9 +44,9 @@ public class ToolExecutionLogRequest {
     @NotNull(message = "Danh sách ID bài học không được để trống")
     List<Long> lessonIds;
 
-    @Schema(description = "WorkspaceId", example = "456", required = true)
-    @NotNull(message = "WorkspaceId không được để trống")
-    Long workspaceId;
+    @Schema(description = "AcademicYearId", example = "456", required = true)
+    @NotNull(message = "AcademicYearId không được để trống")
+    Long academicYearId;
 
     Long resultId;
 

--- a/PlanBook-Aggregator/src/main/java/com/BE/model/response/ToolExecutionLogResponse.java
+++ b/PlanBook-Aggregator/src/main/java/com/BE/model/response/ToolExecutionLogResponse.java
@@ -37,7 +37,7 @@ public class ToolExecutionLogResponse {
             example = "[123, 456, 789]")
     List<Long> lessonIds;
 
-    Long workspaceId;
+    Long academicYearId;
 
     Long resultId;
 

--- a/PlanBook-Aggregator/src/main/java/com/BE/service/implementServices/ToolAggregatorServiceImpl.java
+++ b/PlanBook-Aggregator/src/main/java/com/BE/service/implementServices/ToolAggregatorServiceImpl.java
@@ -87,7 +87,7 @@ public class ToolAggregatorServiceImpl implements IToolAggregatorService {
                 .input(request.getInput())
                 .bookId(request.getBook_id())
                 .lessonIds(lessons)
-                .workspaceId(request.getWorkspaceId())
+                .academicYearId(request.getAcademicYearId())
                 .resultId(request.getResultId())
                 .tokenUsed(internalToolConfigResponse.getData().getTokenCostPerQuery())
                 .build();

--- a/purchase-service/src/main/java/com/BE/service/implementServices/PaymentServiceImpl.java
+++ b/purchase-service/src/main/java/com/BE/service/implementServices/PaymentServiceImpl.java
@@ -108,7 +108,7 @@ public class PaymentServiceImpl implements IPaymentService {
 
         // 3. Kiểm tra trạng thái
         if (StatusEnum.PAID.equals(latest.getStatus()) || StatusEnum.PENDING.equals(latest.getStatus()) || StatusEnum.RETRY.equals(latest.getStatus())) {
-            throw new BusinessException("Không thể retry khi giao dịch cuối cùng đang PENDING hoặc PAID hoặc đã RETRY.");
+            throw new BusinessException("Giao dịch trước đó vẫn đang hoạt động, vui lòng không tạo lại.");
         }
 
         // 4. Gọi tạo mới

--- a/tool-log-service/src/main/java/com/BE/model/entity/ToolExecutionLog.java
+++ b/tool-log-service/src/main/java/com/BE/model/entity/ToolExecutionLog.java
@@ -41,7 +41,7 @@ public class ToolExecutionLog {
     List<Long> lessonIds;
 
     @Column(nullable = false)
-    Long workspaceId;
+    Long academicYearId;
 
     Long resultId;
 

--- a/tool-log-service/src/main/java/com/BE/model/request/CreateToolResultRequest.java
+++ b/tool-log-service/src/main/java/com/BE/model/request/CreateToolResultRequest.java
@@ -27,8 +27,8 @@ public class CreateToolResultRequest {
     @NotNull(message = "userId không được để trống")
     private UUID userId;
 
-    @NotNull(message = "workspaceId không được để trống")
-    private Long workspaceId;
+    @NotNull(message = "academicYearId không được để trống")
+    private Long academicYearId;
 
     @NotNull(message = "type không được để trống")
     @EnumValidator(enumClass = ToolResultType.class, message = "type phải là một trong các giá trị: LESSON_PLAN, SLIDE, EXAM, QUIZ, WORKSHEET, ASSIGNMENT, RUBRIC, CURRICULUM, ACTIVITY, ASSESSMENT, OTHER")

--- a/tool-log-service/src/main/java/com/BE/model/request/ToolExecutionLogRequest.java
+++ b/tool-log-service/src/main/java/com/BE/model/request/ToolExecutionLogRequest.java
@@ -44,9 +44,9 @@ public class ToolExecutionLogRequest {
     @NotNull(message = "Danh sách ID bài học không được để trống")
     List<Long> lessonIds;
 
-    @Schema(description = "WorkspaceId", example = "456", required = true)
-    @NotNull(message = "WorkspaceId không được để trống")
-    Long workspaceId;
+    @Schema(description = "AcademicYearId", example = "456", required = true)
+    @NotNull(message = "AcademicYearId không được để trống")
+    Long academicYearId;
 
     Long resultId;
 

--- a/tool-log-service/src/main/java/com/BE/model/response/ToolExecutionLogResponse.java
+++ b/tool-log-service/src/main/java/com/BE/model/response/ToolExecutionLogResponse.java
@@ -37,7 +37,7 @@ public class ToolExecutionLogResponse {
             example = "[123, 456, 789]")
     List<Long> lessonIds;
 
-    Long workspaceId;
+    Long academicYearId;
 
     Long resultId;
 

--- a/tool-log-service/src/main/java/com/BE/model/response/ToolResultResponse.java
+++ b/tool-log-service/src/main/java/com/BE/model/response/ToolResultResponse.java
@@ -24,7 +24,7 @@ public class ToolResultResponse {
 
     private UUID userId;
 
-    private Long workspaceId;
+    private Long academicYearId;
 
     private ToolResultType type;
 

--- a/tool-log-service/src/main/java/com/BE/service/implementServices/ToolExecutionLogServiceImpl.java
+++ b/tool-log-service/src/main/java/com/BE/service/implementServices/ToolExecutionLogServiceImpl.java
@@ -178,10 +178,10 @@ public class ToolExecutionLogServiceImpl implements IToolExecutionLogService {
                 // 1. Tạo request tạo ToolResult từ dữ liệu của log
                 CreateToolResultRequest request = new CreateToolResultRequest();
                 request.setUserId(log.getUserId());
-                request.setWorkspaceId(log.getWorkspaceId());
+                request.setAcademicYearId(log.getAcademicYearId());
                 request.setType(convertToToolResultType(log.getCode())); // Mapping Enum nếu cùng tên
                 request.setLessonIds(log.getLessonIds());
-                request.setName("Auto Result từ ToolLog " + log.getId()); // Có thể tùy biến theo use-case
+                request.setName("Hệ thống tự động lưu kết quả " + log.getId()); // Có thể tùy biến theo use-case
                 request.setDescription("Tự động tạo từ tool execution log");
                 request.setSource(ToolResultSource.AI);
 //                request.setData(output.getOutput());

--- a/workspace-service/src/main/java/com/BE/controller/ToolResultController.java
+++ b/workspace-service/src/main/java/com/BE/controller/ToolResultController.java
@@ -48,7 +48,7 @@ public class ToolResultController {
                                     value = """
                                             {
                                               "userId": "0d29b45a-5d6a-44e2-b58d-d7aa5180cb0f",
-                                              "workspaceId": 101,
+                                              "academicYearId": 101,
                                               "type": "LESSON_PLAN",
                                               "templateId": 5,
                                               "name": "Giáo án bài 3",
@@ -79,7 +79,7 @@ public class ToolResultController {
                                               "data": {
                                                 "id": 123,
                                                 "userId": "0d29b45a-5d6a-44e2-b58d-d7aa5180cb0f",
-                                                "workspaceId": 101,
+                                                "academicYearId": 101,
                                                 "type": "LESSON_PLAN",
                                                 "templateId": 5,
                                                 "name": "Giáo án bài 3",
@@ -178,7 +178,7 @@ public class ToolResultController {
                                           {
                                             "id": 123,
                                             "userId": "0d29b45a-5d6a-44e2-b58d-d7aa5180cb0f",
-                                            "workspaceId": 101,
+                                            "academicYearId": 101,
                                             "type": "LESSON_PLAN",
                                             "source": "AI",
                                             "name": "Giáo án bài 3",

--- a/workspace-service/src/main/java/com/BE/controller/WorkSpaceController.java
+++ b/workspace-service/src/main/java/com/BE/controller/WorkSpaceController.java
@@ -1,110 +1,110 @@
-package com.BE.controller;
-
-import com.BE.model.request.WorkSpaceRequest;
-import com.BE.model.response.WorkSpaceResponse;
-import com.BE.service.interfaceServices.IWorkSpaceService;
-import com.BE.utils.ResponseHandler;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.UUID;
-
-@RestController
-@Tag(name = "WorkSpaces", description = "API quản lí Workspaces")
-@RequestMapping("/api/workspaces")
-@SecurityRequirement(name = "api")
-public class WorkSpaceController {
-    @Autowired
-    private IWorkSpaceService workSpaceService;
-
-    @Autowired
-    private ResponseHandler responseHandler;
-
-
-    @Operation(summary = "Lấy danh sách tất cả workspace.", description = "Lấy danh sách tất cả workspace.")
-    @ApiResponse(responseCode = "200", description = "Danh sách workspace.")
-    @GetMapping
-    public ResponseEntity getAll() {
-        return responseHandler.response(200, "Lấy tất cả workspace thành công!", workSpaceService.getAll());
-    }
-
-    @Operation(summary = "Lấy thông tin workspace theo id.", description = "Lấy thông tin workspace theo id.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Thông tin workspace.", content = @Content(schema = @Schema(implementation = WorkSpaceResponse.class))),
-            @ApiResponse(responseCode = "404", description = "Không tìm thấy workspace.")
-    })
-    @GetMapping("/{id}")
-    public ResponseEntity getById(@PathVariable Long id) {
-        return responseHandler.response(200, "Lấy workspace theo id thành công!", workSpaceService.getById(id));
-    }
-
-    @Operation(summary = "Tạo mới workspace", description = "Tạo mới workspace cho user trong năm học nhất định.", requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "Dữ liệu tạo workspace mới", required = true, content = @Content(schema = @Schema(implementation = WorkSpaceRequest.class), examples = @ExampleObject(value = "{\"academicYearId\":\"1\"}"))))
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Tạo thành công.", content = @Content(schema = @Schema(implementation = WorkSpaceResponse.class), examples = @ExampleObject(value = "{\"id\":\"long\",\"name\":\"Workspace 2024\",\"academicYearId\":\"long-nam-hoc\",\"userId\":\"uuid-user\"}"))),
-            @ApiResponse(responseCode = "400", description = "Dữ liệu không hợp lệ hoặc thiếu trường bắt buộc."),
-            @ApiResponse(responseCode = "404", description = "Không tìm thấy user hoặc năm học.")
-    })
-    @PostMapping
-    public ResponseEntity create(@Valid @RequestBody WorkSpaceRequest request) {
-        return responseHandler.response(200, "Tạo workspace thành công!", workSpaceService.create(request));
-    }
-
-    @Operation(summary = "Cập nhật thông tin workspace", description = "Cập nhật thông tin workspace theo id.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Cập nhật thành công.", content = @Content(schema = @Schema(implementation = WorkSpaceResponse.class))),
-            @ApiResponse(responseCode = "404", description = "Không tìm thấy workspace, user hoặc năm học.")
-    })
-    @PutMapping("/{id}")
-    public ResponseEntity update(@PathVariable Long id, @Valid @RequestBody WorkSpaceRequest request) {
-        return responseHandler.response(200, "Cập nhật workspace thành công!", workSpaceService.update(id, request));
-    }
-
-    @Operation(summary = "Xóa workspace", description = "Xóa workspace theo id.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Xóa thành công."),
-            @ApiResponse(responseCode = "404", description = "Không tìm thấy workspace.")
-    })
-    @DeleteMapping("/{id}")
-    public ResponseEntity delete(@PathVariable Long id) {
-        workSpaceService.delete(id);
-        return responseHandler.response(200, "Xóa workspace thành công!", 1);
-    }
-
-    @Operation(summary = "Lấy danh sách workspace có phân trang.", description = "Lấy danh sách workspace có phân trang.\n"
-            +
-            "- Chức năng: Trả về danh sách workspace theo từng trang, có thể truyền tham số page, size, sort.\n" +
-            "- Điều kiện: Không cần điều kiện đặc biệt.\n" +
-            "- Dữ liệu vào: page (số trang, bắt đầu từ 0), size (số lượng mỗi trang), sort (ví dụ: name,asc).\n" +
-            "- Ví dụ: /api/workspaces/paged?page=0&size=5&sort=name,asc\n" +
-            "- Đầu ra: Page<WorkSpaceResponse> (content, totalPages, totalElements, ...).\n" +
-            "- Lỗi: Nếu truyền tham số không hợp lệ sẽ trả về lỗi 400.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Lấy danh sách workspace phân trang thành công.", content = @Content(schema = @Schema(implementation = org.springframework.data.domain.Page.class), examples = @ExampleObject(value = "{\"content\":[{...}],\"totalPages\":2,\"totalElements\":10,\"size\":5,\"number\":0}"))),
-            @ApiResponse(responseCode = "400", description = "Tham số phân trang không hợp lệ.")
-    })
-    @GetMapping("/paged")
-    public ResponseEntity getAllPaged(@PageableDefault(size = 10, page = 0) Pageable pageable) {
-        return responseHandler.response(200, "Lấy danh sách workspace phân trang thành công!", workSpaceService.getAll(pageable));
-    }
-
-//    @Operation(summary = "Lấy danh sách workspace của account hiện tại trong năm học đang hoạt động.", description = "Lấy danh sách workspace của account hiện tại trong năm học đang hoạt động.")
-//    @ApiResponse(responseCode = "200", description = "Danh sách workspace của account hiện tại trong năm học active.")
-//    @GetMapping("/my")
-//    public ResponseEntity getMyWorkspaces() {
-//        var filtered = workSpaceService.getCurrentUserWorkspacesInActiveYear();
-//        return responseHandler.response(200, "Lấy workspace của tài khoản hiện tại trong năm học đang hoạt động thành công!",
-//                filtered);
+//package com.BE.controller;
+//
+//import com.BE.model.request.WorkSpaceRequest;
+//import com.BE.model.response.WorkSpaceResponse;
+//import com.BE.service.interfaceServices.IWorkSpaceService;
+//import com.BE.utils.ResponseHandler;
+//import io.swagger.v3.oas.annotations.Operation;
+//import io.swagger.v3.oas.annotations.media.Content;
+//import io.swagger.v3.oas.annotations.media.ExampleObject;
+//import io.swagger.v3.oas.annotations.media.Schema;
+//import io.swagger.v3.oas.annotations.responses.ApiResponse;
+//import io.swagger.v3.oas.annotations.responses.ApiResponses;
+//import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+//import io.swagger.v3.oas.annotations.tags.Tag;
+//import jakarta.validation.Valid;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.data.domain.Pageable;
+//import org.springframework.data.web.PageableDefault;
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.web.bind.annotation.*;
+//
+//import java.util.UUID;
+//
+//@RestController
+//@Tag(name = "WorkSpaces", description = "API quản lí Workspaces")
+//@RequestMapping("/api/workspaces")
+//@SecurityRequirement(name = "api")
+//public class WorkSpaceController {
+//    @Autowired
+//    private IWorkSpaceService workSpaceService;
+//
+//    @Autowired
+//    private ResponseHandler responseHandler;
+//
+//
+//    @Operation(summary = "Lấy danh sách tất cả workspace.", description = "Lấy danh sách tất cả workspace.")
+//    @ApiResponse(responseCode = "200", description = "Danh sách workspace.")
+//    @GetMapping
+//    public ResponseEntity getAll() {
+//        return responseHandler.response(200, "Lấy tất cả workspace thành công!", workSpaceService.getAll());
 //    }
-}
+//
+//    @Operation(summary = "Lấy thông tin workspace theo id.", description = "Lấy thông tin workspace theo id.")
+//    @ApiResponses({
+//            @ApiResponse(responseCode = "200", description = "Thông tin workspace.", content = @Content(schema = @Schema(implementation = WorkSpaceResponse.class))),
+//            @ApiResponse(responseCode = "404", description = "Không tìm thấy workspace.")
+//    })
+//    @GetMapping("/{id}")
+//    public ResponseEntity getById(@PathVariable Long id) {
+//        return responseHandler.response(200, "Lấy workspace theo id thành công!", workSpaceService.getById(id));
+//    }
+//
+//    @Operation(summary = "Tạo mới workspace", description = "Tạo mới workspace cho user trong năm học nhất định.", requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "Dữ liệu tạo workspace mới", required = true, content = @Content(schema = @Schema(implementation = WorkSpaceRequest.class), examples = @ExampleObject(value = "{\"academicYearId\":\"1\"}"))))
+//    @ApiResponses({
+//            @ApiResponse(responseCode = "200", description = "Tạo thành công.", content = @Content(schema = @Schema(implementation = WorkSpaceResponse.class), examples = @ExampleObject(value = "{\"id\":\"long\",\"name\":\"Workspace 2024\",\"academicYearId\":\"long-nam-hoc\",\"userId\":\"uuid-user\"}"))),
+//            @ApiResponse(responseCode = "400", description = "Dữ liệu không hợp lệ hoặc thiếu trường bắt buộc."),
+//            @ApiResponse(responseCode = "404", description = "Không tìm thấy user hoặc năm học.")
+//    })
+//    @PostMapping
+//    public ResponseEntity create(@Valid @RequestBody WorkSpaceRequest request) {
+//        return responseHandler.response(200, "Tạo workspace thành công!", workSpaceService.create(request));
+//    }
+//
+//    @Operation(summary = "Cập nhật thông tin workspace", description = "Cập nhật thông tin workspace theo id.")
+//    @ApiResponses({
+//            @ApiResponse(responseCode = "200", description = "Cập nhật thành công.", content = @Content(schema = @Schema(implementation = WorkSpaceResponse.class))),
+//            @ApiResponse(responseCode = "404", description = "Không tìm thấy workspace, user hoặc năm học.")
+//    })
+//    @PutMapping("/{id}")
+//    public ResponseEntity update(@PathVariable Long id, @Valid @RequestBody WorkSpaceRequest request) {
+//        return responseHandler.response(200, "Cập nhật workspace thành công!", workSpaceService.update(id, request));
+//    }
+//
+//    @Operation(summary = "Xóa workspace", description = "Xóa workspace theo id.")
+//    @ApiResponses({
+//            @ApiResponse(responseCode = "200", description = "Xóa thành công."),
+//            @ApiResponse(responseCode = "404", description = "Không tìm thấy workspace.")
+//    })
+//    @DeleteMapping("/{id}")
+//    public ResponseEntity delete(@PathVariable Long id) {
+//        workSpaceService.delete(id);
+//        return responseHandler.response(200, "Xóa workspace thành công!", 1);
+//    }
+//
+//    @Operation(summary = "Lấy danh sách workspace có phân trang.", description = "Lấy danh sách workspace có phân trang.\n"
+//            +
+//            "- Chức năng: Trả về danh sách workspace theo từng trang, có thể truyền tham số page, size, sort.\n" +
+//            "- Điều kiện: Không cần điều kiện đặc biệt.\n" +
+//            "- Dữ liệu vào: page (số trang, bắt đầu từ 0), size (số lượng mỗi trang), sort (ví dụ: name,asc).\n" +
+//            "- Ví dụ: /api/workspaces/paged?page=0&size=5&sort=name,asc\n" +
+//            "- Đầu ra: Page<WorkSpaceResponse> (content, totalPages, totalElements, ...).\n" +
+//            "- Lỗi: Nếu truyền tham số không hợp lệ sẽ trả về lỗi 400.")
+//    @ApiResponses({
+//            @ApiResponse(responseCode = "200", description = "Lấy danh sách workspace phân trang thành công.", content = @Content(schema = @Schema(implementation = org.springframework.data.domain.Page.class), examples = @ExampleObject(value = "{\"content\":[{...}],\"totalPages\":2,\"totalElements\":10,\"size\":5,\"number\":0}"))),
+//            @ApiResponse(responseCode = "400", description = "Tham số phân trang không hợp lệ.")
+//    })
+//    @GetMapping("/paged")
+//    public ResponseEntity getAllPaged(@PageableDefault(size = 10, page = 0) Pageable pageable) {
+//        return responseHandler.response(200, "Lấy danh sách workspace phân trang thành công!", workSpaceService.getAll(pageable));
+//    }
+//
+////    @Operation(summary = "Lấy danh sách workspace của account hiện tại trong năm học đang hoạt động.", description = "Lấy danh sách workspace của account hiện tại trong năm học đang hoạt động.")
+////    @ApiResponse(responseCode = "200", description = "Danh sách workspace của account hiện tại trong năm học active.")
+////    @GetMapping("/my")
+////    public ResponseEntity getMyWorkspaces() {
+////        var filtered = workSpaceService.getCurrentUserWorkspacesInActiveYear();
+////        return responseHandler.response(200, "Lấy workspace của tài khoản hiện tại trong năm học đang hoạt động thành công!",
+////                filtered);
+////    }
+//}

--- a/workspace-service/src/main/java/com/BE/mapper/ToolResultMapper.java
+++ b/workspace-service/src/main/java/com/BE/mapper/ToolResultMapper.java
@@ -33,7 +33,7 @@ public interface ToolResultMapper {
      */
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "userId", ignore = true)
-    @Mapping(target = "workspaceId", ignore = true)
+    @Mapping(target = "academicYearId", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)

--- a/workspace-service/src/main/java/com/BE/mapper/WorkSpaceMapper.java
+++ b/workspace-service/src/main/java/com/BE/mapper/WorkSpaceMapper.java
@@ -1,17 +1,17 @@
-package com.BE.mapper;
-
-
-import com.BE.model.entity.WorkSpace;
-import com.BE.model.response.WorkSpaceResponse;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.factory.Mappers;
-
-@Mapper(componentModel = "spring")
-public interface WorkSpaceMapper {
-    WorkSpaceMapper INSTANCE = Mappers.getMapper(WorkSpaceMapper.class);
-
-//    @Mapping(target = "academicYearId", source = "academicYear.id")
-//    @Mapping(target = "userId", source = "user.id")
-    WorkSpaceResponse toResponse(WorkSpace entity);
-}
+//package com.BE.mapper;
+//
+//
+//import com.BE.model.entity.WorkSpace;
+//import com.BE.model.response.WorkSpaceResponse;
+//import org.mapstruct.Mapper;
+//import org.mapstruct.Mapping;
+//import org.mapstruct.factory.Mappers;
+//
+//@Mapper(componentModel = "spring")
+//public interface WorkSpaceMapper {
+//    WorkSpaceMapper INSTANCE = Mappers.getMapper(WorkSpaceMapper.class);
+//
+////    @Mapping(target = "academicYearId", source = "academicYear.id")
+////    @Mapping(target = "userId", source = "user.id")
+//    WorkSpaceResponse toResponse(WorkSpace entity);
+//}

--- a/workspace-service/src/main/java/com/BE/model/entity/AcademicYear.java
+++ b/workspace-service/src/main/java/com/BE/model/entity/AcademicYear.java
@@ -31,7 +31,7 @@ public class AcademicYear {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    @OneToMany(mappedBy = "academicYear", cascade = CascadeType.ALL)
-    private Set<WorkSpace> workSpaces = new HashSet<>();
+//    @OneToMany(mappedBy = "academicYear", cascade = CascadeType.ALL)
+//    private Set<WorkSpace> workSpaces = new HashSet<>();
 
 }

--- a/workspace-service/src/main/java/com/BE/model/entity/ToolResult.java
+++ b/workspace-service/src/main/java/com/BE/model/entity/ToolResult.java
@@ -33,7 +33,7 @@ public class ToolResult {
     UUID userId;
 
     @Column(nullable = false)
-    Long workspaceId;
+    Long academicYearId;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)

--- a/workspace-service/src/main/java/com/BE/model/entity/WorkSpace.java
+++ b/workspace-service/src/main/java/com/BE/model/entity/WorkSpace.java
@@ -1,38 +1,38 @@
-package com.BE.model.entity;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
-import org.hibernate.annotations.UuidGenerator;
-import java.util.UUID;
-import lombok.Getter;
-import lombok.Setter;
-
-@Entity
-@Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
-public class WorkSpace {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    Long id;
-
-    @JsonIgnore
-    @ManyToOne
-    @JoinColumn(name = "academic_year_id")
-    private AcademicYear academicYear;
-
-
-    @CreationTimestamp
-    String createdAt;
-
-    @UpdateTimestamp
-    String updatedAt;
-
-    // Getters and setters
-}
+//package com.BE.model.entity;
+//
+//import com.fasterxml.jackson.annotation.JsonIgnore;
+//import jakarta.persistence.*;
+//import lombok.AllArgsConstructor;
+//import lombok.NoArgsConstructor;
+//import org.hibernate.annotations.CreationTimestamp;
+//import org.hibernate.annotations.UpdateTimestamp;
+//import org.hibernate.annotations.UuidGenerator;
+//import java.util.UUID;
+//import lombok.Getter;
+//import lombok.Setter;
+//
+//@Entity
+//@Getter
+//@Setter
+//@AllArgsConstructor
+//@NoArgsConstructor
+//public class WorkSpace {
+//
+//    @Id
+//    @GeneratedValue(strategy = GenerationType.IDENTITY)
+//    Long id;
+//
+//    @JsonIgnore
+//    @ManyToOne
+//    @JoinColumn(name = "academic_year_id")
+//    private AcademicYear academicYear;
+//
+//
+//    @CreationTimestamp
+//    String createdAt;
+//
+//    @UpdateTimestamp
+//    String updatedAt;
+//
+//    // Getters and setters
+//}

--- a/workspace-service/src/main/java/com/BE/model/request/CreateToolResultRequest.java
+++ b/workspace-service/src/main/java/com/BE/model/request/CreateToolResultRequest.java
@@ -27,8 +27,8 @@ public class CreateToolResultRequest {
     @NotNull(message = "userId không được để trống")
     private UUID userId;
 
-    @NotNull(message = "workspaceId không được để trống")
-    private Long workspaceId;
+    @NotNull(message = "academicYearId không được để trống")
+    private Long academicYearId;
 
     @NotNull(message = "type không được để trống")
     @EnumValidator(enumClass = ToolResultType.class, message = "type phải là một trong các giá trị: LESSON_PLAN, SLIDE, EXAM, QUIZ, WORKSHEET, ASSIGNMENT, RUBRIC, CURRICULUM, ACTIVITY, ASSESSMENT, OTHER")

--- a/workspace-service/src/main/java/com/BE/model/request/ToolResultFilterRequest.java
+++ b/workspace-service/src/main/java/com/BE/model/request/ToolResultFilterRequest.java
@@ -23,8 +23,8 @@ public class ToolResultFilterRequest {
     @Schema(description = "ID người dùng", example = "0d29b45a-5d6a-44e2-b58d-d7aa5180cb0f")
     private UUID userId;
 
-    @Schema(description = "ID workspace", example = "101")
-    private Long workspaceId;
+    @Schema(description = "ID AcademicYear", example = "101")
+    private Long academicYearId;
 
     @EnumValidator(enumClass = ToolResultType.class, message = "type phải là một trong các giá trị hợp lệ")
     @Schema(description = "Loại kết quả công cụ", example = "LESSON_PLAN")
@@ -70,8 +70,8 @@ public class ToolResultFilterRequest {
         return userId != null;
     }
 
-    public boolean hasWorkspaceId() {
-        return workspaceId != null;
+    public boolean hasAcademicYearId() {
+        return academicYearId != null;
     }
 
     public boolean hasType() {
@@ -104,7 +104,7 @@ public class ToolResultFilterRequest {
     }
 
     public boolean hasAnyFilter() {
-        return hasUserId() || hasWorkspaceId() || hasType() || hasStatus() || hasSource()
+        return hasUserId() || hasAcademicYearId() || hasType() || hasStatus() || hasSource()
                 || hasTemplateId() || hasNameContains() || hasDescriptionContains()
                 || hasLessonIds();
     }

--- a/workspace-service/src/main/java/com/BE/model/request/WorkSpaceRequest.java
+++ b/workspace-service/src/main/java/com/BE/model/request/WorkSpaceRequest.java
@@ -1,19 +1,19 @@
-package com.BE.model.request;
-
-import java.util.UUID;
-
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
-public class WorkSpaceRequest {
-
-    @NotNull(message = "academicYearId cannot be blank")
-    private Long academicYearId;
-
-}
+//package com.BE.model.request;
+//
+//import java.util.UUID;
+//
+//import jakarta.validation.constraints.NotBlank;
+//import jakarta.validation.constraints.NotNull;
+//import lombok.AllArgsConstructor;
+//import lombok.Data;
+//import lombok.NoArgsConstructor;
+//
+//@Data
+//@AllArgsConstructor
+//@NoArgsConstructor
+//public class WorkSpaceRequest {
+//
+//    @NotNull(message = "academicYearId cannot be blank")
+//    private Long academicYearId;
+//
+//}

--- a/workspace-service/src/main/java/com/BE/model/response/ToolResultResponse.java
+++ b/workspace-service/src/main/java/com/BE/model/response/ToolResultResponse.java
@@ -24,7 +24,7 @@ public class ToolResultResponse {
 
     private UUID userId;
 
-    private Long workspaceId;
+    private Long academicYearId;
 
     private ToolResultType type;
 

--- a/workspace-service/src/main/java/com/BE/model/response/WorkSpaceResponse.java
+++ b/workspace-service/src/main/java/com/BE/model/response/WorkSpaceResponse.java
@@ -1,17 +1,17 @@
-package com.BE.model.response;
-
-import java.util.UUID;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
-public class WorkSpaceResponse {
-    private Long id;
-    private AcademicYearResponse academicYear;
-//    private UUID userId;
-    private String createdAt;
-    private String updatedAt;
-}
+//package com.BE.model.response;
+//
+//import java.util.UUID;
+//import lombok.AllArgsConstructor;
+//import lombok.Data;
+//import lombok.NoArgsConstructor;
+//
+//@Data
+//@AllArgsConstructor
+//@NoArgsConstructor
+//public class WorkSpaceResponse {
+//    private Long id;
+//    private AcademicYearResponse academicYear;
+////    private UUID userId;
+//    private String createdAt;
+//    private String updatedAt;
+//}

--- a/workspace-service/src/main/java/com/BE/repository/WorkSpaceRepository.java
+++ b/workspace-service/src/main/java/com/BE/repository/WorkSpaceRepository.java
@@ -1,10 +1,10 @@
-package com.BE.repository;
-
-
-import com.BE.model.entity.WorkSpace;
-import org.springframework.data.jpa.repository.JpaRepository;
-import java.util.UUID;
-
-
-public interface WorkSpaceRepository extends JpaRepository<WorkSpace, Long> {
-}
+//package com.BE.repository;
+//
+//
+//import com.BE.model.entity.WorkSpace;
+//import org.springframework.data.jpa.repository.JpaRepository;
+//import java.util.UUID;
+//
+//
+//public interface WorkSpaceRepository extends JpaRepository<WorkSpace, Long> {
+//}

--- a/workspace-service/src/main/java/com/BE/service/implementServices/AcademicYearServiceImpl.java
+++ b/workspace-service/src/main/java/com/BE/service/implementServices/AcademicYearServiceImpl.java
@@ -7,7 +7,6 @@ import com.BE.model.entity.AcademicYear;
 import com.BE.model.request.AcademicYearRequest;
 import com.BE.model.response.AcademicYearResponse;
 import com.BE.repository.AcademicYearRepository;
-import com.BE.repository.WorkSpaceRepository;
 import com.BE.service.interfaceServices.IAcademicYearService;
 import com.BE.utils.DateNowUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,8 +26,8 @@ public class AcademicYearServiceImpl implements IAcademicYearService {
     private AcademicYearRepository academicYearRepository;
 //    @Autowired
 //    private AuthenRepository authenRepository;
-    @Autowired
-    private WorkSpaceRepository workSpaceRepository;
+//    @Autowired
+//    private WorkSpaceRepository workSpaceRepository;
     @Autowired
     private AcademicYearMapper academicYearMapper;
 

--- a/workspace-service/src/main/java/com/BE/service/implementServices/ToolResultServiceImpl.java
+++ b/workspace-service/src/main/java/com/BE/service/implementServices/ToolResultServiceImpl.java
@@ -35,7 +35,7 @@ public class ToolResultServiceImpl implements IToolResultService {
     @Override
     public ToolResultResponse create(CreateToolResultRequest request) {
         log.info("Tạo mới ToolResult với userId: {}, workspaceId: {}, type: {}",
-                request.getUserId(), request.getWorkspaceId(), request.getType());
+                request.getUserId(), request.getAcademicYearId(), request.getType());
 
         try {
             ToolResult entity = toolResultMapper.toEntity(request);
@@ -97,7 +97,7 @@ public class ToolResultServiceImpl implements IToolResultService {
             // Build Specification từ filter request
             Specification<ToolResult> specification = ToolResultSpecification.buildSpecification(
                     filterRequest.getUserId(),
-                    filterRequest.getWorkspaceId(),
+                    filterRequest.getAcademicYearId(),
                     filterRequest.getType(),
                     filterRequest.getStatus(),
                     filterRequest.getSource(),

--- a/workspace-service/src/main/java/com/BE/service/implementServices/WorkSpaceServiceImpl.java
+++ b/workspace-service/src/main/java/com/BE/service/implementServices/WorkSpaceServiceImpl.java
@@ -1,111 +1,111 @@
-package com.BE.service.implementServices;
-
-import com.BE.exception.exceptions.BadRequestException;
-import com.BE.mapper.WorkSpaceMapper;
-import com.BE.model.entity.AcademicYear;
-import com.BE.model.entity.WorkSpace;
-import com.BE.model.request.WorkSpaceRequest;
-import com.BE.model.response.WorkSpaceResponse;
-import com.BE.repository.AcademicYearRepository;
-import com.BE.repository.WorkSpaceRepository;
-import com.BE.service.interfaceServices.IWorkSpaceService;
-import com.BE.utils.AccountUtils;
-import com.BE.service.interfaceServices.IAcademicYearService;
-import com.BE.utils.DateNowUtils;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-@Service
-public class WorkSpaceServiceImpl implements IWorkSpaceService {
-    @Autowired
-    private WorkSpaceRepository workSpaceRepository;
-    @Autowired
-    private AcademicYearRepository academicYearRepository;
+//package com.BE.service.implementServices;
+//
+//import com.BE.exception.exceptions.BadRequestException;
+//import com.BE.mapper.WorkSpaceMapper;
+//import com.BE.model.entity.AcademicYear;
+//import com.BE.model.entity.WorkSpace;
+//import com.BE.model.request.WorkSpaceRequest;
+//import com.BE.model.response.WorkSpaceResponse;
+//import com.BE.repository.AcademicYearRepository;
+//import com.BE.repository.WorkSpaceRepository;
+//import com.BE.service.interfaceServices.IWorkSpaceService;
+//import com.BE.utils.AccountUtils;
+//import com.BE.service.interfaceServices.IAcademicYearService;
+//import com.BE.utils.DateNowUtils;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.data.domain.Page;
+//import org.springframework.data.domain.Pageable;
+//import org.springframework.stereotype.Service;
+//
+//import java.util.List;
+//import java.util.UUID;
+//import java.util.stream.Collectors;
+//
+//@Service
+//public class WorkSpaceServiceImpl implements IWorkSpaceService {
 //    @Autowired
-//    private AuthenRepository authenRepository;
-    @Autowired
-    private WorkSpaceMapper workSpaceMapper;
-    @Autowired
-    private AccountUtils accountUtils;
-    @Autowired
-    private IAcademicYearService academicYearService;
-
-    @Autowired
-    private DateNowUtils dateNowUtils;
-
-    @Override
-    public List<WorkSpaceResponse> getAll() {
-        return workSpaceRepository.findAll().stream()
-                .map(workSpaceMapper::toResponse)
-                .collect(Collectors.toList());
-    }
-
-    @Override
-    public WorkSpaceResponse getById(Long id) {
-        WorkSpace ws = workSpaceRepository.findById(id)
-                .orElseThrow(() -> new BadRequestException("Không tìm thấy không gian làm việc"));
-        return workSpaceMapper.toResponse(ws);
-    }
-
-    @Override
-    public WorkSpaceResponse create(WorkSpaceRequest request) {
-        WorkSpace ws = new WorkSpace();
-//        ws.setName(request.getName());
-
-        AcademicYear ay = academicYearRepository.findById(request.getAcademicYearId())
-                .orElseThrow(() -> new BadRequestException("Không tìm thấy năm học"));
-//        User user = authenRepository.findById(request.getUserId())
-//                .orElseThrow(() -> new BadRequestException("Không tìm thấy người dùng"));
-//        ws.setUser(user);
-        ws.setAcademicYear(ay);
-        return workSpaceMapper.toResponse(workSpaceRepository.save(ws));
-    }
-
-    @Override
-    public WorkSpaceResponse update(Long id, WorkSpaceRequest request) {
-        WorkSpace ws = workSpaceRepository.findById(id)
-                .orElseThrow(() -> new BadRequestException("Không tìm thấy không gian làm việc"));
-//        ws.setName(request.getName());
-        AcademicYear ay = academicYearRepository.findById(request.getAcademicYearId())
-                .orElseThrow(() -> new BadRequestException("Không tìm thấy năm học"));
-//        User user = authenRepository.findById(request.getUserId())
-//                .orElseThrow(() -> new BadRequestException("Không tìm thấy người dùng"));
-//        ws.setUser(user);
-        ws.setAcademicYear(ay);
-        return workSpaceMapper.toResponse(workSpaceRepository.save(ws));
-    }
-
-    @Override
-    public void delete(Long id) {
-        workSpaceRepository.deleteById(id);
-    }
-
-    @Override
-    public Page<WorkSpaceResponse> getAll(Pageable pageable) {
-        return workSpaceRepository.findAll(pageable).map(workSpaceMapper::toResponse);
-    }
-
+//    private WorkSpaceRepository workSpaceRepository;
+//    @Autowired
+//    private AcademicYearRepository academicYearRepository;
+////    @Autowired
+////    private AuthenRepository authenRepository;
+//    @Autowired
+//    private WorkSpaceMapper workSpaceMapper;
+//    @Autowired
+//    private AccountUtils accountUtils;
+//    @Autowired
+//    private IAcademicYearService academicYearService;
+//
+//    @Autowired
+//    private DateNowUtils dateNowUtils;
+//
 //    @Override
-//    public List<WorkSpaceResponse> getCurrentUserWorkspacesInActiveYear() {
-//        User user = accountUtils.getCurrentUser();
-//        AcademicYear activeYear = academicYearService.getActiveAcademicYear();
-//        if (activeYear == null)
-//            return List.of();
-//        return user.getWorkSpaces().stream()
-//                .filter(ws -> ws.getAcademicYear() != null
-//                        && ws.getAcademicYear().getId().equals(activeYear.getId()))
+//    public List<WorkSpaceResponse> getAll() {
+//        return workSpaceRepository.findAll().stream()
 //                .map(workSpaceMapper::toResponse)
-//                .toList();
+//                .collect(Collectors.toList());
 //    }
-
-    @Override
-    public void save(WorkSpace workSpace) {
-        workSpaceRepository.save(workSpace);
-    }
-}
+//
+//    @Override
+//    public WorkSpaceResponse getById(Long id) {
+//        WorkSpace ws = workSpaceRepository.findById(id)
+//                .orElseThrow(() -> new BadRequestException("Không tìm thấy không gian làm việc"));
+//        return workSpaceMapper.toResponse(ws);
+//    }
+//
+//    @Override
+//    public WorkSpaceResponse create(WorkSpaceRequest request) {
+//        WorkSpace ws = new WorkSpace();
+////        ws.setName(request.getName());
+//
+//        AcademicYear ay = academicYearRepository.findById(request.getAcademicYearId())
+//                .orElseThrow(() -> new BadRequestException("Không tìm thấy năm học"));
+////        User user = authenRepository.findById(request.getUserId())
+////                .orElseThrow(() -> new BadRequestException("Không tìm thấy người dùng"));
+////        ws.setUser(user);
+//        ws.setAcademicYear(ay);
+//        return workSpaceMapper.toResponse(workSpaceRepository.save(ws));
+//    }
+//
+//    @Override
+//    public WorkSpaceResponse update(Long id, WorkSpaceRequest request) {
+//        WorkSpace ws = workSpaceRepository.findById(id)
+//                .orElseThrow(() -> new BadRequestException("Không tìm thấy không gian làm việc"));
+////        ws.setName(request.getName());
+//        AcademicYear ay = academicYearRepository.findById(request.getAcademicYearId())
+//                .orElseThrow(() -> new BadRequestException("Không tìm thấy năm học"));
+////        User user = authenRepository.findById(request.getUserId())
+////                .orElseThrow(() -> new BadRequestException("Không tìm thấy người dùng"));
+////        ws.setUser(user);
+//        ws.setAcademicYear(ay);
+//        return workSpaceMapper.toResponse(workSpaceRepository.save(ws));
+//    }
+//
+//    @Override
+//    public void delete(Long id) {
+//        workSpaceRepository.deleteById(id);
+//    }
+//
+//    @Override
+//    public Page<WorkSpaceResponse> getAll(Pageable pageable) {
+//        return workSpaceRepository.findAll(pageable).map(workSpaceMapper::toResponse);
+//    }
+//
+////    @Override
+////    public List<WorkSpaceResponse> getCurrentUserWorkspacesInActiveYear() {
+////        User user = accountUtils.getCurrentUser();
+////        AcademicYear activeYear = academicYearService.getActiveAcademicYear();
+////        if (activeYear == null)
+////            return List.of();
+////        return user.getWorkSpaces().stream()
+////                .filter(ws -> ws.getAcademicYear() != null
+////                        && ws.getAcademicYear().getId().equals(activeYear.getId()))
+////                .map(workSpaceMapper::toResponse)
+////                .toList();
+////    }
+//
+//    @Override
+//    public void save(WorkSpace workSpace) {
+//        workSpaceRepository.save(workSpace);
+//    }
+//}

--- a/workspace-service/src/main/java/com/BE/service/interfaceServices/IAcademicYearService.java
+++ b/workspace-service/src/main/java/com/BE/service/interfaceServices/IAcademicYearService.java
@@ -2,7 +2,6 @@ package com.BE.service.interfaceServices;
 
 import com.BE.enums.AcademicYearStatusEnum;
 import com.BE.model.entity.AcademicYear;
-import com.BE.model.entity.WorkSpace;
 import com.BE.model.request.AcademicYearRequest;
 import com.BE.model.response.AcademicYearResponse;
 

--- a/workspace-service/src/main/java/com/BE/service/interfaceServices/IWorkSpaceService.java
+++ b/workspace-service/src/main/java/com/BE/service/interfaceServices/IWorkSpaceService.java
@@ -1,27 +1,27 @@
-package com.BE.service.interfaceServices;
-
-import com.BE.model.request.WorkSpaceRequest;
-import com.BE.model.response.WorkSpaceResponse;
-import java.util.List;
-import java.util.UUID;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import com.BE.model.entity.WorkSpace;
-
-public interface IWorkSpaceService {
-    List<WorkSpaceResponse> getAll();
-
-    WorkSpaceResponse getById(Long id);
-
-    WorkSpaceResponse create(WorkSpaceRequest request);
-
-    WorkSpaceResponse update(Long id, WorkSpaceRequest request);
-
-    void delete(Long id);
-
-    Page<WorkSpaceResponse> getAll(Pageable pageable);
-
-//    List<WorkSpaceResponse> getCurrentUserWorkspacesInActiveYear();
-
-    void save(WorkSpace workSpace);
-}
+//package com.BE.service.interfaceServices;
+//
+//import com.BE.model.request.WorkSpaceRequest;
+//import com.BE.model.response.WorkSpaceResponse;
+//import java.util.List;
+//import java.util.UUID;
+//import org.springframework.data.domain.Page;
+//import org.springframework.data.domain.Pageable;
+//import com.BE.model.entity.WorkSpace;
+//
+//public interface IWorkSpaceService {
+//    List<WorkSpaceResponse> getAll();
+//
+//    WorkSpaceResponse getById(Long id);
+//
+//    WorkSpaceResponse create(WorkSpaceRequest request);
+//
+//    WorkSpaceResponse update(Long id, WorkSpaceRequest request);
+//
+//    void delete(Long id);
+//
+//    Page<WorkSpaceResponse> getAll(Pageable pageable);
+//
+////    List<WorkSpaceResponse> getCurrentUserWorkspacesInActiveYear();
+//
+//    void save(WorkSpace workSpace);
+//}

--- a/workspace-service/src/main/java/com/BE/specification/ToolResultSpecification.java
+++ b/workspace-service/src/main/java/com/BE/specification/ToolResultSpecification.java
@@ -21,7 +21,7 @@ public class ToolResultSpecification {
      */
     public static Specification<ToolResult> buildSpecification(
             UUID userId,
-            Long workspaceId,
+            Long academicYearId,
             ToolResultType type,
             ToolResultStatus status,
             ToolResultSource source,
@@ -39,8 +39,8 @@ public class ToolResultSpecification {
             }
 
             // Filter theo workspaceId
-            if (workspaceId != null) {
-                predicates.add(criteriaBuilder.equal(root.get("workspaceId"), workspaceId));
+            if (academicYearId != null) {
+                predicates.add(criteriaBuilder.equal(root.get("academicYearId"), academicYearId));
             }
 
             // Filter theo type


### PR DESCRIPTION
- Updated ToolExecutionLogRequest to replace workspaceId with academicYearId.
- Modified ToolExecutionLogResponse and ToolResultResponse to reflect changes in ID references.
- Refactored ToolExecutionLogServiceImpl to utilize academicYearId in result creation.
- Adjusted ToolResultController to handle academicYearId in API examples and responses.
- Revised WorkSpaceController to incorporate academicYearId in request and response models.
- Updated mappers (ToolResultMapper, WorkSpaceMapper) to ignore workspaceId and use academicYearId.
- Commented out unused workspace-related code in AcademicYear, ToolResult, WorkSpace entities, and WorkSpaceServiceImpl.
- Altered CreateToolResultRequest and ToolResultFilterRequest to utilize academicYearId.
- Adjusted specifications in ToolResultSpecification to filter by academicYearId instead of workspaceId.